### PR TITLE
test: pvt key old way to test buffer/encrypt failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ _It is being watched by the GH-Scrum-Poker Marketplace App beta_
 - test #3
 - test #4
 - test #5 (add arrow fn syntax to pr event listener in request)
+- test #6 (testing pvt key buffer for error (using reliable pem path))


### PR DESCRIPTION
# 🚀 Summary

This merge implements testing the old key using the file path instead of an buffer base 64 encryption which could be bug prone
