### PR TITLE
test!: change all env vars to initial github app tutorial keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ _It is being watched by the GH-Scrum-Poker Marketplace App beta_
 - test #7 (changed all env vars to match first tutorial GH app id, webhook secret, key)
   - if test #7 works that implies some sort of misfire with setting up the GH Scrum Poker app on GH?
   - the app on GH is the wrong app and we are sending it the wrong credentials. How do I configure which App on GH we are sending to??
+- test #8 (made sure GH Tutorial app is watching only colin/scrum-poker-test && changed to correct pvt key PATH for node server)
+
+
+- test #7 continued...
+  - I have a bad feeling the GH app that is running on GH and expecting a request is my very first tutorial based app.
+  - I wonder where I miss-stepped in the configuration of that app on GH GUI.
+  - Or, if having too many up on GH is bad? Redirecting webhook payloads from multiple apps? All to one proxy?

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ _It is being watched by the GH-Scrum-Poker Marketplace App beta_
 - test #4
 - test #5 (add arrow fn syntax to pr event listener in request)
 - test #6 (testing pvt key buffer for error (using reliable pem path))
+- test #7 (changed all env vars to match first tutorial GH app id, webhook secret, key)
+  - if test #7 works that implies some sort of misfire with setting up the GH Scrum Poker app on GH?
+  - the app on GH is the wrong app and we are sending it the wrong credentials. How do I configure which App on GH we are sending to??


### PR DESCRIPTION
# 🚀 Summary

I have a bad feeling the GH app that is running on GH and expecting a request is my very first tutorial based app.
I wonder where I miss-stepped in the configuration of that app on GH GUI.
Or, if having too many up on GH is bad? Redirecting webhook payloads from multiple apps? All to one proxy?

## 📝 How can we Reproduce/Test?

Please provide instructions so we can reproduce:

- test #7 (changed all env vars to match first tutorial GH app id, webhook secret, key)
  - if test #7 works that implies some sort of misfire with setting up the GH Scrum Poker app on GH?
  - the app on GH is the wrong app and we are sending it the wrong credentials. How do I configure which App on GH we are sending to??